### PR TITLE
feature(fivetran_sdk): add support for LocalTime Datatype

### DIFF
--- a/common.proto
+++ b/common.proto
@@ -79,14 +79,14 @@ enum DataType {
   DECIMAL = 5;
   FLOAT = 6;
   DOUBLE = 7;
-  NAIVE_DATE = 8;
-  NAIVE_DATETIME = 9;
-  UTC_DATETIME = 10;
-  BINARY = 11;
-  XML = 12;
-  STRING = 13;
-  JSON = 14;
-  NAIVE_TIME = 15;
+  NAIVE_TIME = 8;
+  NAIVE_DATE = 9;
+  NAIVE_DATETIME = 10;
+  UTC_DATETIME = 11;
+  BINARY = 12;
+  XML = 13;
+  STRING = 14;
+  JSON = 15;
 }
 
 message DecimalParams {
@@ -110,15 +110,15 @@ message ValueType {
     int64 long = 5;
     float float = 6;
     double double = 7;
-    google.protobuf.Timestamp naive_date = 8;
-    google.protobuf.Timestamp naive_datetime = 9;
-    google.protobuf.Timestamp utc_datetime = 10;
-    string decimal = 11;
-    bytes binary = 12;
-    string string = 13;
-    string json = 14;
-    string xml = 15;
-    google.protobuf.Timestamp naive_time = 16;
+    google.protobuf.Timestamp naive_time = 8;
+    google.protobuf.Timestamp naive_date = 9;
+    google.protobuf.Timestamp naive_datetime = 10;
+    google.protobuf.Timestamp utc_datetime = 11;
+    string decimal = 12;
+    bytes binary = 13;
+    string string = 14;
+    string json = 15;
+    string xml = 16;
   }
 }
 

--- a/common.proto
+++ b/common.proto
@@ -86,6 +86,7 @@ enum DataType {
   XML = 12;
   STRING = 13;
   JSON = 14;
+  NAIVE_TIME = 15;
 }
 
 message DecimalParams {
@@ -117,6 +118,7 @@ message ValueType {
     string string = 13;
     string json = 14;
     string xml = 15;
+    google.protobuf.Timestamp naive_time = 16;
   }
 }
 

--- a/development-guide.md
+++ b/development-guide.md
@@ -125,8 +125,9 @@ Examples of each [DataType](https://github.com/fivetran/fivetran_sdk/blob/main/c
 - DECIMAL: Floating point values with max precision of 38 and max scale of 37
 - FLOAT: Single-precision 32-bit IEEE 754 values, e.g. 3.4028237E+38
 - DOUBLE: Double-precision 64-bit IEEE 754 values, e.g. -2.2250738585072014E-308
-- NAIVE_DATE: Date without a timezone in ISO-8601 calendar system, e.g. 2007-12-03
-- NAIVE_DATETIME: A date-time without timezone in ISO-8601 calendar system, e.g. 2007-12-03T10:15:30
+- NAIVE_TIME: Time without a timezone in the ISO-8601 calendar system, e.g. 10:15:30 
+- NAIVE_DATE: Date without a timezone in the ISO-8601 calendar system, e.g. 2007-12-03
+- NAIVE_DATETIME: A date-time without timezone in the ISO-8601 calendar system, e.g. 2007-12-03T10:15:30
 - UTC_DATETIME: An instantaneous point on the timeline, always in UTC timezone, e.g. 2007-12-03T10:15:30.123Z
 - BINARY: Binary data is represented as protobuf `bytes` (e.g. [ByteString](https://github.com/protocolbuffers/protobuf/blob/main/java/core/src/main/java/com/google/protobuf/ByteString.java))
 - XML: "`<tag>`This is xml`</tag>`"


### PR DESCRIPTION
Link: T-584141

### Description of change
Added support for LocalTime Datatype 
Note: This should be merged after [this](https://github.com/fivetran/engineering/pull/172194) PR is merged.

### Testing
- Able to pass NaiveTime data type for column and row values as well.
<img width="1051" alt="Screenshot 2024-03-26 at 3 20 13 PM" src="https://github.com/fivetran/fivetran_sdk/assets/54502802/5f8eeeb7-33b3-4e39-bcaa-224d5f27150d">
<img width="1064" alt="Screenshot 2024-03-26 at 3 20 26 PM" src="https://github.com/fivetran/fivetran_sdk/assets/54502802/6771b0e5-b292-4007-97f5-741fe8b02705">
