### PR TITLE
fix(fivetran_sdk): Update guide to not consider backslash as escape char

### DIFF
--- a/development-guide.md
+++ b/development-guide.md
@@ -88,6 +88,7 @@ Batch files are compressed using [ZSTD](https://en.wikipedia.org/wiki/Zstd)
 - Currently we only support CSV file format
 - Each batch file is size limited to 100MB
 - Number of records in each batch file can vary depending on row size
+- Fivetran create batch file using ```com.fasterxml.jackson.dataformat.csv.CsvSchema``` which by default doesn't consider backslash as escape character. If you are reading the batch file then make sure that you do not consider backslash as escape character.
 
 ### RPC Calls
 #### CreateTable


### PR DESCRIPTION
We create CSV split file as:
```
CsvSchema.Builder builder = CsvSchema.builder();
for (Column c : finalColumns) builder.addColumn(c.name, csvType(c.type));
CsvSchema csvSchema = builder.setUseHeader(true).setNullValue(DataWriter.WAREHOUSE_NULL).build();
CSV.configure(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM, false);
```
And by Default in CSVSchema no escape character is used and thus we can create spit file as:
```
id,val,name,_fivetran_synced
1,"abc , \",abdul,2024-05-09T10:22:59.588Z
2,"abcd ",salam,2024-05-09T10:22:59.621Z
```

Updated development guide indicating this so partner do not consider backslash as escape character.