### PR TITLE
doc(tester): add pre requisite info

### DIFF
--- a/development-guide.md
+++ b/development-guide.md
@@ -50,6 +50,7 @@ The executable needs to do the following:
 - Partner code should handle any source and destination-related errors.
 - Partner code should retry any transient errors internally without deferring them to Fivetran.
 - Partner code should use [gRPC built-in error mechanism](https://grpc.io/docs/guides/error/#language-support) to relay errors instead of throwing exceptions and abruptly closing the connection.
+- Partner code should capture and relay a clear message when the account permissions are not sufficient.
 
 ### User tasks
 

--- a/doc-templates/destination-connector-templates/destination-setup-guide-template.md
+++ b/doc-templates/destination-connector-templates/destination-setup-guide-template.md
@@ -20,10 +20,10 @@ To connect a {Destination} to Fivetran, you need the following:
 {List what the user needs to know or do before they get started}
 
 - A Fivetran role with the [Create Destinations or Manage Destinations](/docs/using-fivetran/fivetran-dashboard/account-settings/role-based-access-control#rbacpermissions) permissions
-- Administrator account {this is an example}
+- Administrator account {this is an example}*
 - Version 17 of Acme installed {this is an example}
     
-    > NOTE: This section should include the minimum level account tier that is required by the customer to setup a destination 
+    > \*NOTE: If you have an account tier system, this section should specify the minimum account tier required for your customers to set up a destination.
 
 ---
 

--- a/doc-templates/destination-connector-templates/destination-setup-guide-template.md
+++ b/doc-templates/destination-connector-templates/destination-setup-guide-template.md
@@ -22,6 +22,8 @@ To connect a {Destination} to Fivetran, you need the following:
 - A Fivetran role with the [Create Destinations or Manage Destinations](/docs/using-fivetran/fivetran-dashboard/account-settings/role-based-access-control#rbacpermissions) permissions
 - Administrator account {this is an example}
 - Version 17 of Acme installed {this is an example}
+    
+    > NOTE: This section should include the minimum level account tier that is required by the customer to setup a destination 
 
 ---
 


### PR DESCRIPTION
links: T-815728 
Closes T-840533
The destination setup requires a base account level to facilitate seamless processing of data. This needs to be added in the docs. Added the guideline in the documentation guide.