### PR TITLE
Emrah feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ This repo consists of example source and destination connectors along with a loc
 ## Development
 Follow the [SDK Development Guide](development-guide.md) for guidance on how to develop your code. 
 
-> NOTE: If you're a new partner that just started working with the Connector SDK, use [V2 release](https://github.com/fivetran/fivetran_sdk/releases/tag/v2). We will continue to support [V1 release](https://github.com/fivetran/fivetran_sdk/releases/tag/v1) for partners that have used them to build their SDK connectors, and these will be removed once the migration to V2 is complete.
-
 Once you have your code ready to run:
 1. Start up your connector running on port 50051 (for destination code, use port 50052).
 2. Run the local test environment.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo consists of example source and destination connectors along with a loc
 * [Local Testing Tools](tools/)
 
 ## Development
-You can follow the [SDK Development Guide](development-guide.md) for guidance on how to develop your code. 
+Follow the [SDK Development Guide](development-guide.md) for guidance on how to develop your code. 
 
 > NOTE: If you're a new partner that just started working with the Connector SDK, use [V2 release](https://github.com/fivetran/fivetran_sdk/releases/tag/v2). We will continue to support [V1 release](https://github.com/fivetran/fivetran_sdk/releases/tag/v1) for partners that have used them to build their SDK connectors, and these will be removed once the migration to V2 is complete.
 

--- a/development-guide.md
+++ b/development-guide.md
@@ -1,6 +1,11 @@
 # SDK Development Guide
 
+## Getting Started
+
 Fivetran SDK uses [gRPC](https://grpc.io/) to talk to partner code. The partner side of the interface is always the server side. Fivetran implements the client side and initiates the requests.
+
+Start by using one of the examples as a template for your new SDK connector. If we don't have an example in 
+your language, create a new gRPC server project in your language of choice using the protobuf definition files at the root of this repo.
 
 ## General guidelines
 

--- a/development-guide.md
+++ b/development-guide.md
@@ -6,7 +6,7 @@ Fivetran SDK uses [gRPC](https://grpc.io/) to talk to partner code. The partner 
 
 ### Versions
 * gRPC: 1.61.1
-* protobuf: 3.25.2
+* protobuf: 4.28.3
 
 ### Language
 


### PR DESCRIPTION
The following items are my feedback based on trying to create a source SDK connector. They are not addressed in this PR, we'll need to create separate tickets for them:

* Java example defines the following:
```
    private final String INFO = "INFO";
    private final String WARNING = "WARNING";
    private final String SEVERE = "SEVERE";
```
Examples should use standard logging and configured to log messages to STDOUT. Let's get rid of custom `logMessages()` method and these string constants.

* Update example IJ settings to Java 17