### PR TITLE
doc(Fivetran_sdk):Source and destination connection doc update as per the feedback:

### DIFF
--- a/tools/destination-connector-tester/README.md
+++ b/tools/destination-connector-tester/README.md
@@ -10,17 +10,17 @@
    
     - Authenticate Docker to Google Artifact Registry: Run the following command to allow Docker to use your Google credentials
     ```
-        gcloud auth configure-docker us-docker.pkg.dev
+   gcloud auth configure-docker us-docker.pkg.dev
     ```
     - Pull the Image: 
     ```
-        docker pull us-docker.pkg.dev/build-286712/public-docker-us/sdktesters-v2/sdk-tester:<version> 
+   docker pull us-docker.pkg.dev/build-286712/public-docker-us/sdktesters-v2/sdk-tester:<version> 
     ```
 
 2. Run a container using the image with the following command. Make sure to map a local directory for the tool by replacing `<local-data-folder>` placeholders in the command, and replace `<version>` with the version of the image you pulled.
 
 ```
-docker run --mount type=bind,source=<local-data-folder>,target=/data -a STDIN -a STDOUT -a STDERR -it -e WORKING_DIR=<local-data-folder> -e GRPC_HOSTNAME=host.docker.internal --network=host us-docker.pkg.dev/build-286712/public-docker-us/sdktesters-v2/sdk-tester:<version> --tester-type destination --port <port>
+docker run --mount type=bind,source=<local-data-folder>,target=/data -a STDIN -a STDOUT -a STDERR -it -e WORKING_DIR=<local-data-folder> -e GRPC_HOSTNAME=host.docker.internal --network=host us-docker.pkg.dev/build-286712/public-docker-us/sdktesters-v2/sdk-tester:<version> --tester-type destination --port 50052
 ```
 
 3. To rerun the container from step #2, use the following command:

--- a/tools/source-connector-tester/README.md
+++ b/tools/source-connector-tester/README.md
@@ -11,17 +11,17 @@
 
     - Authenticate Docker to Google Artifact Registry: Run the following command to allow Docker to use your Google credentials
     ```
-        gcloud auth configure-docker us-docker.pkg.dev
+   gcloud auth configure-docker us-docker.pkg.dev
     ```
     - Pull the Image:
     ```
-        docker pull us-docker.pkg.dev/build-286712/public-docker-us/sdktesters-v2/sdk-tester:<version>   
+   docker pull us-docker.pkg.dev/build-286712/public-docker-us/sdktesters-v2/sdk-tester:<version>   
     ```
    
 2. Run a container using the image with the following command. Make sure to map a local directory for storing files that the tool generates by replacing `<local-data-folder>` in the command, and replace <version> with the version of the image you pulled.
 
 ```
-docker run --mount type=bind,source=<local-data-folder>,target=/data -a STDIN -a STDOUT -a STDERR -it -e GRPC_HOSTNAME=host.docker.internal --network=host us-docker.pkg.dev/build-286712/public-docker-us/sdktesters-v2/sdk-tester:<version> --tester-type source --port <port>
+docker run --mount type=bind,source=<local-data-folder>,target=/data -a STDIN -a STDOUT -a STDERR -it -e GRPC_HOSTNAME=host.docker.internal --network=host us-docker.pkg.dev/build-286712/public-docker-us/sdktesters-v2/sdk-tester:<version> --tester-type source --port 50051
 ```
 
 3. Once the sync is done running, it will persist the records in a `warehouse.db` database file. This is an instance of [DuckDB](https://duckdb.org/) database. You can connect to it to validate the results of your sync using [DuckDB CLI](https://duckdb.org/docs/api/cli) or [DBeaver](https://duckdb.org/docs/guides/sql_editors/dbeaver)


### PR DESCRIPTION
Closes [T-896217](https://fivetran.height.app/T-896217)

### Description of Change

#### What does the change do?
The following changes are done for both source and destination connectors:
1. Run commands(1) - removed whitespaces
2. Run command(2) - added the port that needs to be used