### PR TITLE
doc(partner-sdk): Adding text for multiple earliest_start_files and _fivetran_start

### DIFF
--- a/how-to-handle-history-mode-batch-files.md
+++ b/how-to-handle-history-mode-batch-files.md
@@ -20,17 +20,17 @@ The following types of files are a part of the `WriteHistoryBatchRequest` gRPC c
 In `WriteHistoryBatchRequest`, we pass a new field, `earliest_start_files`. This file contains a single record for each primary key in the incoming batch, with the earliest `_fivetran_start`. It is also important to note that there can be multiple `earliest_start_files`.
 
 For this file, the following operations must be implemented in the exact order as they are listed:
-1. Removing any overlapping records where existing `_fivetran_start` is greater than the `earliest_fivetran_start` timestamp value in the `earliest_start_files` file:
+1. Removing any overlapping records where existing `_fivetran_start` is greater than the earliest `_fivetran_start` timestamp value in the `earliest_start_files` file:
   
    ```sql
-   DELETE FROM <schema.table> WHERE pk1 = <val> {AND  pk2 = <val>.....} AND _fivetran_start >= val<_earliest_fivetran_start>;
+   DELETE FROM <schema.table> WHERE pk1 = <val> {AND  pk2 = <val>.....} AND _fivetran_start >= val<_fivetran_start>;
    ```
    > The `_fivetran_start` column should NOT be included as part of the primary key filters (`pk1`, `pk2`, etc.) in the WHERE clause or joins. Primary key filters or joins should only include the actual table primary keys (`pk1`, `pk2`, etc.).
    
-2. Updating of the values of the history mode-specific system columns `fivetran_active` and `fivetran_end` in the destination. 
+2. Updating of the values of the history mode-specific system columns `fivetran_active` and `fivetran_end` in the destination. The `fivetran_end` column is set to exactly 1 millisecond earlier than the earliest `_fivetran_start` timestamp value in the `earliest_start_files` file.
     
   ```sql
-  UPDATE <schema.table> SET fivetran_active = FALSE, _fivetran_end = earliest_fivetran_start - 1 msec WHERE _fivetran_active = TRUE AND pk1 = <val> {AND  pk2 = <val>.....}`
+  UPDATE <schema.table> SET fivetran_active = FALSE, _fivetran_end = _fivetran_start - 1 msec WHERE _fivetran_active = TRUE AND pk1 = <val> {AND  pk2 = <val>.....}`
   ```
 
 #### `update_files`

--- a/how-to-handle-history-mode-batch-files.md
+++ b/how-to-handle-history-mode-batch-files.md
@@ -25,7 +25,7 @@ For this file, the following operations must be implemented in the exact order a
    ```sql
    DELETE FROM <schema.table> WHERE pk1 = <val> {AND  pk2 = <val>.....} AND _fivetran_start >= val<_fivetran_start>;
    ```
-   > The `_fivetran_start` column should NOT be included as part of the primary key filters (`pk1`, `pk2`, etc.) in the WHERE clause or joins. Primary key filters or joins should only include the actual table primary keys (`pk1`, `pk2`, etc.).
+   > IMPORTANT: The `_fivetran_start` column should NOT be included as part of the primary key filters (`pk1`, `pk2`, etc.) in the WHERE clause or joins. Primary key filters or joins should only include the actual table primary keys (`pk1`, `pk2`, etc.).
    
 2. Updating of the values of the history mode-specific system columns `fivetran_active` and `fivetran_end` in the destination. The `fivetran_end` column is set to exactly 1 millisecond earlier than the earliest `_fivetran_start` timestamp value in the `earliest_start_files` file.
     

--- a/how-to-handle-history-mode-batch-files.md
+++ b/how-to-handle-history-mode-batch-files.md
@@ -17,7 +17,7 @@ The following types of files are a part of the `WriteHistoryBatchRequest` gRPC c
 
 #### `earliest_start_files`
 
-In `WriteHistoryBatchRequest`, we pass a new field, `earliest_start_files`. This file contains a single record for each primary key in the incoming batch, with the earliest `_fivetran_start`.
+In `WriteHistoryBatchRequest`, we pass a new field, `earliest_start_files`. This file contains a single record for each primary key in the incoming batch, with the earliest `_fivetran_start`. It is also important to note that there can be multiple `earliest_start_files`.
 
 For this file, the following operations must be implemented in the exact order as they are listed:
 1. Removing any overlapping records where existing `_fivetran_start` is greater than the `earliest_fivetran_start` timestamp value in the `earliest_start_files` file:
@@ -25,8 +25,9 @@ For this file, the following operations must be implemented in the exact order a
    ```sql
    DELETE FROM <schema.table> WHERE pk1 = <val> {AND  pk2 = <val>.....} AND _fivetran_start >= val<_earliest_fivetran_start>;
    ```
-
-3. Updating of the values of the history mode-specific system columns `fivetran_active` and `fivetran_end` in the destination. 
+   > The `_fivetran_start` column should NOT be included as part of the primary key filters (`pk1`, `pk2`, etc.) in the WHERE clause or joins. Primary key filters or joins should only include the actual table primary keys (`pk1`, `pk2`, etc.).
+   
+2. Updating of the values of the history mode-specific system columns `fivetran_active` and `fivetran_end` in the destination. 
     
   ```sql
   UPDATE <schema.table> SET fivetran_active = FALSE, _fivetran_end = earliest_fivetran_start - 1 msec WHERE _fivetran_active = TRUE AND pk1 = <val> {AND  pk2 = <val>.....}`

--- a/tools/destination-connector-tester/README.md
+++ b/tools/destination-connector-tester/README.md
@@ -110,7 +110,7 @@ Here is an example input file named `input_1.json`:
       {
          "update": {
             "transaction": [
-               {"id":1, "amount": 200 ,"op_time":"2005-05-24T20:57:00Z"},
+               {"id":1, "amount": 200 ,"op_time":"2005-05-24T20:58:00Z"},
                {"id":5, "amount": 200 ,"op_time":"2005-05-24T20:57:00Z"}
             ]
          }
@@ -124,7 +124,7 @@ Here is an example input file named `input_1.json`:
          "upsert": {
             "transaction": [
                {"id":10, "amount": 200, "desc": "three", "op_time":"2005-05-26T20:57:00Z"},
-               {"id":10, "amount": 100, "desc": "thee", "op_time":"2005-05-26T20:57:00Z"},
+               {"id":10, "amount": 100, "desc": "thee", "op_time":"2005-05-26T20:58:00Z"},
                {"id":20, "amount": 50, "desc": "mone", "op_time":"2005-05-26T21:57:00Z"}
             ],
             "campaign": [


### PR DESCRIPTION
closes https://fivetran.height.app/T-907104

Adding the text in [this file](./how-to-handle-history-mode-batch-files.md) to address the following:
- mention that  `_fivetran_start` should not be part of `pk1 = <val> {AND pk2 = <val>.....}`,  primary key filters/joins
-  mentioning there can be multiple `earliest_start_files`

![Screenshot 2025-03-11 at 21 33 03](https://github.com/user-attachments/assets/d87ed349-cb05-4ac6-a3b6-8f6e63aec994)
