### PR TITLE
doc(schema_migration):small note for ADD_COLUMN_WITH_DEFAULT_VALUE

### DIFF
--- a/schema-migration-helper-service.md
+++ b/schema-migration-helper-service.md
@@ -78,7 +78,9 @@ If the ALTER TABLE query doesn't support the DEFAULT clause, then:
     UPDATE <schema.table> SET <column_name> = <default_value>;
     ```
 
-> Note: If the ADD_COLUMN_WITH_DEFAULT_VALUE migration results in an unsupported error, Fivetran will fall back to using the already implemented `AlterTable` RPC implementation to create a new table. Please note that the new table will not contain any historical (back-dated) data.
+> Note: 
+> 1. If the ADD_COLUMN_WITH_DEFAULT_VALUE migration results in an unsupported error, Fivetran will fall back to using the already implemented `AlterTable` RPC implementation to create a new table. Please note that the new table will not contain any historical (back-dated) data.
+> 2. If the column already exists in the table, Fivetran will still send an `ADD_COLUMN_WITH_DEFAULT_VALUE` request. In this case, your implementation should skip the `ADD COLUMN` step (to avoid an error) but still execute the `UPDATE` to set the default value on all existing rows. This ensures rows that were present before the column was added receive the correct default value.
 
 ---
 

--- a/schema-migration-helper-service.md
+++ b/schema-migration-helper-service.md
@@ -79,8 +79,8 @@ If the ALTER TABLE query doesn't support the DEFAULT clause, then:
     ```
 
 > Note: 
-> 1. If the ADD_COLUMN_WITH_DEFAULT_VALUE migration results in an unsupported error, Fivetran will fall back to using the already implemented `AlterTable` RPC implementation to create a new table. Please note that the new table will not contain any historical (back-dated) data.
-> 2. If the column already exists in the table, Fivetran will still send an `ADD_COLUMN_WITH_DEFAULT_VALUE` request. In this case, your implementation should skip the `ADD COLUMN` step (to avoid an error) but still execute the `UPDATE` to set the default value on all existing rows. This ensures rows that were present before the column was added receive the correct default value.
+> 1. If the ADD_COLUMN_WITH_DEFAULT_VALUE migration results in an unsupported error, Fivetran falls back to using the already implemented `AlterTable` RPC implementation to create a new table. The new table won't contain any historical (back-dated) data.
+> 2. If the column already exists in the table, Fivetran still sends an `ADD_COLUMN_WITH_DEFAULT_VALUE` request. In this case, your implementation should skip the `ADD COLUMN` step (to avoid an error) but still execute the `UPDATE` to set the default value on all existing rows. This ensures that rows that existed before the column was added receive the correct default value.
 
 ---
 


### PR DESCRIPTION
Partner's confusion: https://fivetran.slack.com/archives/C05PULD9DGR/p1775553320942889?thread_ts=1775536152.562269&cid=C05PULD9DGR

### Description
Update the doc to add a note for ADD_COLUMN_WITH_DEFAULT_VALUE to update value even if col exists to avoid Partner's getting confused. 